### PR TITLE
Add optional parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 rvm:
-  - 2.0.0
   - 2.1.0
   - 2.2.5
   - 2.3.1

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ For instance:
 
 ## Ruby versions supported
 
-* 2.0.0
 * 2.1.0
 * 2.2.5
 * 2.3.1
+* 2.4.0
 
 Check the [.travis.yml](.travis.yml) to see the current supported ruby versions.
 

--- a/README.md
+++ b/README.md
@@ -26,22 +26,31 @@ Or install it yourself as:
     client = NYCGeoClient::Client.new(app_id: 'ID', app_key: 'KEY')
 
     # get block and property level information about an address
-    client.address('13', 'crosby', 'manhattan')
+    client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
 
     # property level information about a tax lot
-    client.bbl('manhattan', '00233', '0004')
+    client.bbl(borough: 'manhattan', block: '00233', lot: '0004')
 
     # get property level information about a building
-    client.bin('1003041')
+    client.bin(bin: '1003041')
 
     # get information about a segment defined by an on street between two cross-streets
-    client.blockface('34 st', 'fifth ave', 'sixth ave', 'manhattan')
+    client.blockface(
+        on_street: '34 st',
+        cross_street_one: 'fifth ave',
+        cross_street_two: 'sixth ave',
+        borough: 'manhattan'
+    )
 
     # get information about a point defined by two cross streets
-    client.intersection('34 st', 'fifth ave', 'manhattan')
+    client.intersection(
+        cross_street_one: '34 st',
+        cross_street_two: 'fifth ave',
+        borough: 'manhattan'
+    )
 
     # get address information using a well-known place name
-    client.place('empire state building', 'manhattan')
+    client.place(name: 'empire state building', borough: 'manhattan')
 
 
 For more information about the data returned by every method please check the specs folder
@@ -69,11 +78,10 @@ For instance:
     require 'typhoeus/adapters/faraday' # You will need the typhoeus gem
 
     client = NYCGeoClient.client(adapter: :typhoeus, user_agent: "foobar v1", debug: true, app_id: 'foo', app_key: 'bar')
-    client.address('13','crosby','manhattan')
+    client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
 
 ## Ruby versions supported
 
-* 1.9.3
 * 2.0.0
 * 2.1.0
 * 2.2.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  gem:
+    image: ruby:2.4.0
+    depends_on:
+      - nyc-geoclient
+    volumes:
+      - .:/opt/nyc_geo_client
+  nyc-geoclient:
+    container_name: nyc-geoclient
+    image: 'delner/geoclient:16b'
+    expose:
+      - 8080

--- a/lib/nyc_geo_client/client/address.rb
+++ b/lib/nyc_geo_client/client/address.rb
@@ -15,12 +15,13 @@ module NYCGeoClient
       # @example block and property level information about an address
       #   NYCGeoClient.address('13', 'crosby', 'manhattan')
       # @format :json, :xml
-      def address(house_number, street, borough)
+      def address(house_number:, street:, borough: nil, zip: nil)
         options = {
           houseNumber: house_number,
           street: street,
-          borough: borough
-        }
+          borough: borough,
+          zip: zip
+        }.reject { |k, v| v.nil? }
         get(address_path, options)
       end
 

--- a/lib/nyc_geo_client/client/bbl.rb
+++ b/lib/nyc_geo_client/client/bbl.rb
@@ -12,7 +12,7 @@ module NYCGeoClient
       # @example property level information about a tax lot
       #   NYCGeoClient.bbl('manhattan','00233', '0004')
       # @format :json, :xml
-      def bbl(borough, block, lot)
+      def bbl(borough:, block:, lot:)
         options = {
           block:   block,
           lot:     lot,

--- a/lib/nyc_geo_client/client/bin.rb
+++ b/lib/nyc_geo_client/client/bin.rb
@@ -10,7 +10,7 @@ module NYCGeoClient
       # @example property level information about a building
       #   NYCGeoClient.bin('1003041')
       # @format :json, :xml
-      def bin(bin)
+      def bin(bin:)
         options = {
           bin: bin
         }

--- a/lib/nyc_geo_client/client/blockface.rb
+++ b/lib/nyc_geo_client/client/blockface.rb
@@ -17,13 +17,16 @@ module NYCGeoClient
       # @example information about a segment defined by an on street between two cross-streets
       #   NYCGeoClient.blockface('34 st', 'fifht ave', 'sixth ave', 'manhattan')
       # @format :json, :xml
-      def blockface(on_street, cross_street_one, cross_street_two, borough, extra = {})
+      def blockface(on_street:, cross_street_one:, cross_street_two:, borough:, borough_cross_street_one: nil, borough_cross_street_two: nil, compass_direction: nil)
         options = {
           onStreet:    on_street,
           crossStreetOne: cross_street_one,
           crossStreetTwo: cross_street_two,
-          borough: borough
-        }.merge(extra)
+          borough: borough,
+          boroughCrossStreetOne: borough_cross_street_one,
+          boroughCrossStreetTwo: borough_cross_street_two,
+          compassDirection: compass_direction
+        }.reject { |k, v| v.nil? }
         get(blockface_path, options)
       end
 

--- a/lib/nyc_geo_client/client/intersection.rb
+++ b/lib/nyc_geo_client/client/intersection.rb
@@ -15,12 +15,14 @@ module NYCGeoClient
       # @example information about a segment defined by an on street between two cross-streets
       #   NYCGeoClient.blockface('34 st', 'fifht ave', 'manhattan')
       # @format :json, :xml
-      def intersection(cross_street_one, cross_street_two, borough, extra = {})
+      def intersection(cross_street_one:, cross_street_two:, borough:, borough_cross_street_two: nil, compass_direction: nil)
         options = {
           crossStreetOne: cross_street_one,
           crossStreetTwo: cross_street_two,
-          borough: borough
-        }.merge(extra)
+          borough: borough,
+          boroughCrossStreetTwo: borough_cross_street_two,
+          compassDirection: compass_direction
+        }.reject { |k, v| v.nil? }
         get(intersection_path, options)
       end
 

--- a/lib/nyc_geo_client/client/place.rb
+++ b/lib/nyc_geo_client/client/place.rb
@@ -11,11 +11,12 @@ module NYCGeoClient
       # @example address information using a well-known place name
       #   NYCGeoClient.place('empire state building')
       # @format :json, :xml
-      def place(name, borough)
+      def place(name:, borough: nil, zip: nil)
         options = {
           name:    name,
-          borough: borough
-        }
+          borough: borough,
+          zip: zip
+        }.reject { |k, v| v.nil? }
         get(place_path, options)
       end
 

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -22,13 +22,13 @@ describe Faraday::Response do
 
       it "should raise a NYCGeoClient error" do
         expect(lambda do
-          @client.address('13','crosby','manhattan')
+          @client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
         end).to raise_error(NYCGeoClient::Error)
       end
 
       it "should return the status and body" do
         begin
-          @client.address('13','crosby','manhattan')
+          @client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
         rescue NYCGeoClient::Error => ex
           expect(ex.status).to eq status
           parts = ex.message.split(": ")

--- a/spec/nyc_geo_client/client/address_spec.rb
+++ b/spec/nyc_geo_client/client/address_spec.rb
@@ -10,34 +10,68 @@ describe NYCGeoClient::Client do
       end
 
       describe ".address" do
-        before do
-          stub_get("address.#{format}").
-            with(
-              query: {
+        context 'given a borough' do
+          before do
+            stub_get("address.#{format}").
+              with(
+                query: {
+                  app_id: @client.app_id,
+                  app_key: @client.app_key,
+                  houseNumber: '13',
+                  street: 'crosby',
+                  borough: 'manhattan'
+                }).
+              to_return(body: fixture("address.#{format}"), headers: {content_type: "application/#{format}; charset=utf-8"})
+          end
+
+          it "should get the correct resource" do
+            @client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
+            expect(a_get("address.#{format}").
+              with(query: {
                 app_id: @client.app_id,
                 app_key: @client.app_key,
                 houseNumber: '13',
                 street: 'crosby',
                 borough: 'manhattan'
-              }).
-            to_return(body: fixture("address.#{format}"), headers: {content_type: "application/#{format}; charset=utf-8"})
+              })).to have_been_made
+          end
+
+          it "should return the address info" do
+            data = @client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
+            expect(data.keys).to eq ["address"]
+          end
         end
 
-        it "should get the correct resource" do
-          @client.address('13', 'crosby', 'manhattan')
-          expect(a_get("address.#{format}").
-            with(query: {
-              app_id: @client.app_id,
-              app_key: @client.app_key,
-              houseNumber: '13',
-              street: 'crosby',
-              borough: 'manhattan'
-            })).to have_been_made
-        end
+        context 'given a ZIP' do
+          before do
+            stub_get("address.#{format}").
+              with(
+                query: {
+                  app_id: @client.app_id,
+                  app_key: @client.app_key,
+                  houseNumber: '13',
+                  street: 'crosby',
+                  zip: '10013'
+                }).
+              to_return(body: fixture("address.#{format}"), headers: {content_type: "application/#{format}; charset=utf-8"})
+          end
 
-        it "should return the address info" do
-          data = @client.address('13', 'crosby', 'manhattan')
-          expect(data.keys).to eq ["address"]
+          it "should get the correct resource" do
+            @client.address(house_number: '13', street: 'crosby', zip: '10013')
+            expect(a_get("address.#{format}").
+              with(query: {
+                app_id: @client.app_id,
+                app_key: @client.app_key,
+                houseNumber: '13',
+                street: 'crosby',
+                zip: '10013'
+              })).to have_been_made
+          end
+
+          it "should return the address info" do
+            data = @client.address(house_number: '13', street: 'crosby', zip: '10013')
+            expect(data.keys).to eq ["address"]
+          end
         end
       end
     end

--- a/spec/nyc_geo_client/client/bbl_spec.rb
+++ b/spec/nyc_geo_client/client/bbl_spec.rb
@@ -24,7 +24,7 @@ describe NYCGeoClient::Client do
         end
 
         it "should get the correct resource" do
-          @client.bbl('manhattan', '00233', '0004')
+          @client.bbl(borough: 'manhattan', block: '00233', lot: '0004')
           expect(a_get("bbl.#{format}").
             with(query: {
               app_id:  @client.app_id,
@@ -36,7 +36,7 @@ describe NYCGeoClient::Client do
         end
 
         it "should return the bbl info" do
-          data = @client.bbl('manhattan', '00233', '0004')
+          data = @client.bbl(borough: 'manhattan', block: '00233', lot: '0004')
           expect(data.keys).to eq ["bbl"]
         end
       end

--- a/spec/nyc_geo_client/client/bin_spec.rb
+++ b/spec/nyc_geo_client/client/bin_spec.rb
@@ -22,7 +22,7 @@ describe NYCGeoClient::Client do
         end
 
         it "should get the correct resource" do
-          @client.bin('1003041')
+          @client.bin(bin: '1003041')
           expect(a_get("bin.#{format}").
             with(query: {
               app_id:  @client.app_id,
@@ -32,7 +32,7 @@ describe NYCGeoClient::Client do
         end
 
         it "should return the bin info" do
-          data = @client.bin('1003041')
+          data = @client.bin(bin: '1003041')
           expect(data.keys).to eq ["bin"]
         end
       end

--- a/spec/nyc_geo_client/client/blockface_spec.rb
+++ b/spec/nyc_geo_client/client/blockface_spec.rb
@@ -26,7 +26,14 @@ describe NYCGeoClient::Client do
         end
 
         it "should get the correct resource" do
-          @client.blockface('34 st', 'fifth ave', 'sixth ave', 'manhattan', {compassDirection: 'north'})
+          @client.blockface(
+            on_street: '34 st',
+            cross_street_one: 'fifth ave',
+            cross_street_two: 'sixth ave',
+            borough: 'manhattan',
+            compass_direction: 'north'
+          )
+
           expect(a_get("blockface.#{format}").
             with(query: {
               app_id:  @client.app_id,
@@ -40,7 +47,14 @@ describe NYCGeoClient::Client do
         end
 
         it "should return the blockface info" do
-          data = @client.blockface('34 st', 'fifth ave', 'sixth ave', 'manhattan', {compassDirection: 'north'})
+          data = @client.blockface(
+            on_street: '34 st',
+            cross_street_one: 'fifth ave',
+            cross_street_two: 'sixth ave',
+            borough: 'manhattan',
+            compass_direction: 'north'
+          )
+
           expect(data.keys).to eq ["blockface"]
         end
       end

--- a/spec/nyc_geo_client/client/intersection_spec.rb
+++ b/spec/nyc_geo_client/client/intersection_spec.rb
@@ -25,7 +25,13 @@ describe NYCGeoClient::Client do
         end
 
         it "should get the correct resource" do
-          @client.intersection('34 st', 'fifth ave', 'manhattan', {compassDirection: 'north'})
+          @client.intersection(
+            cross_street_one: '34 st',
+            cross_street_two: 'fifth ave',
+            borough: 'manhattan',
+            compass_direction: 'north'
+          )
+
           expect(a_get("intersection.#{format}").
             with(query: {
               app_id:  @client.app_id,
@@ -38,7 +44,13 @@ describe NYCGeoClient::Client do
         end
 
         it "should return the intersection info" do
-          data = @client.intersection('34 st', 'fifth ave', 'manhattan', {compassDirection: 'north'})
+          data = @client.intersection(
+            cross_street_one: '34 st',
+            cross_street_two: 'fifth ave',
+            borough: 'manhattan',
+            compass_direction: 'north'
+          )
+
           expect(data.keys).to eq ["intersection"]
         end
       end

--- a/spec/nyc_geo_client/client/place_spec.rb
+++ b/spec/nyc_geo_client/client/place_spec.rb
@@ -10,32 +10,64 @@ describe NYCGeoClient::Client do
       end
 
       describe ".place" do
-        before do
-          stub_get("place.#{format}").
-            with(
-              query: {
+        context 'given a borough' do
+          before do
+            stub_get("place.#{format}").
+              with(
+                query: {
+                  app_id:  @client.app_id,
+                  app_key: @client.app_key,
+                  name:    'empire state building',
+                  borough: 'manhattan'
+                }).
+              to_return(body: fixture("place.#{format}"), headers: {content_type: "application/#{format}; charset=utf-8"})
+          end
+
+          it "should get the correct resource" do
+            @client.place(name: 'empire state building', borough: 'manhattan')
+            expect(a_get("place.#{format}").
+              with(query: {
                 app_id:  @client.app_id,
                 app_key: @client.app_key,
                 name:    'empire state building',
                 borough: 'manhattan'
-              }).
-            to_return(body: fixture("place.#{format}"), headers: {content_type: "application/#{format}; charset=utf-8"})
+              })).to have_been_made
+          end
+
+          it "should return the place info" do
+            data = @client.place(name: 'empire state building', borough: 'manhattan')
+            expect(data.keys).to eq ["place"]
+          end
         end
 
-        it "should get the correct resource" do
-          @client.place('empire state building', 'manhattan')
-          expect(a_get("place.#{format}").
-            with(query: {
-              app_id:  @client.app_id,
-              app_key: @client.app_key,
-              name:    'empire state building',
-              borough: 'manhattan'
-            })).to have_been_made
-        end
+        context 'given a zip' do
+          before do
+            stub_get("place.#{format}").
+              with(
+                query: {
+                  app_id:  @client.app_id,
+                  app_key: @client.app_key,
+                  name: 'empire state building',
+                  zip: '10118'
+                }).
+              to_return(body: fixture("place.#{format}"), headers: {content_type: "application/#{format}; charset=utf-8"})
+          end
 
-        it "should return the place info" do
-          data = @client.place('empire state building', 'manhattan')
-          expect(data.keys).to eq ["place"]
+          it "should get the correct resource" do
+            @client.place(name: 'empire state building', zip: '10118')
+            expect(a_get("place.#{format}").
+              with(query: {
+                app_id:  @client.app_id,
+                app_key: @client.app_key,
+                name: 'empire state building',
+                zip: '10118'
+              })).to have_been_made
+          end
+
+          it "should return the place info" do
+            data = @client.place(name: 'empire state building', zip: '10118')
+            expect(data.keys).to eq ["place"]
+          end
         end
       end
     end

--- a/spec/nyc_geo_client_spec.rb
+++ b/spec/nyc_geo_client_spec.rb
@@ -19,7 +19,7 @@ describe NYCGeoClient do
       end
 
     it "should get the correct resource" do
-      NYCGeoClient.address('13', 'crosby', 'manhattan')
+      NYCGeoClient.address(house_number: '13', street: 'crosby', borough: 'manhattan')
       expect(a_get("address.json").
         with(query: {
           houseNumber: '13',
@@ -29,7 +29,17 @@ describe NYCGeoClient do
     end
 
      it "should return the same results as a client" do
-       expect(NYCGeoClient.address('13', 'crosby', 'manhattan')).to eq NYCGeoClient::Client.new.address('13', 'crosby', 'manhattan')
+      expect(
+        NYCGeoClient.address(
+          house_number: '13',
+          street: 'crosby',
+          borough: 'manhattan'
+        )
+      ).to eq NYCGeoClient::Client.new.address(
+        house_number: '13',
+        street: 'crosby',
+        borough: 'manhattan'
+      )
      end
 
    end


### PR DESCRIPTION
Currently the `address` and `place` endpoints do not support searching by ZIP code.

This pull request updates all the endpoints with their optional parameters, and converts their argument list to keywords. This is a new feature for Ruby 2.1.0+.

Instead of:

```ruby
client.address('13', 'crosby', 'manhattan')
```

You pass keyword arguments such as:

```ruby
client.address(house_number: '13', street: 'crosby', borough: 'manhattan')
client.address(house_number: '13', street: 'crosby', zip: '10013')
```

This change is a breaking change, and would require a semantic version update to the gem.

PR back to upstream: https://github.com/edgar/NYCGeoClient/pull/2